### PR TITLE
Add support for verified Medium aliases

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -66,9 +66,7 @@
         "https://writingcooperative.com/*",
         "https://www.eruditeelders.com/*",
         "https://yc.prosetech.com/*",
-        "https://stories.byburk.net/*",
-        "https://theinnovationhub.medium.com/*",
-        "https://neuralnetworkpress.com/*"
+        "https://stories.byburk.net/*"
       ],
       "js": [
         "content.js"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -65,7 +65,10 @@
         "https://uxdesign.cc/*",
         "https://writingcooperative.com/*",
         "https://www.eruditeelders.com/*",
-        "https://yc.prosetech.com/*"
+        "https://yc.prosetech.com/*",
+        "https://stories.byburk.net/*",
+        "https://theinnovationhub.medium.com/*",
+        "https://neuralnetworkpress.com/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
This PR updates the `manifest.json` to add support for the following **verified Medium-powered domains**:

- `https://stories.byburk.net/*`
- `https://theinnovationhub.medium.com/*`
- `https://neuralnetworkpress.com/*`

Each domain was:
- Confirmed to be hosted on Medium
- Displays paywalled content
- Works with Freedium redirection

These were extracted from a previous PR (#24 ) and refined based on your feedback.

Thank you for maintaining this extension!
